### PR TITLE
Implemented #40 Implement Signer Signing + Verification (ed25519)

### DIFF
--- a/packages/signer/.env.example
+++ b/packages/signer/.env.example
@@ -1,3 +1,3 @@
 # Signer Configuration
-# PRIVATE_KEY=your_private_key_here
+# PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_ED25519_PKCS8_PEM\n-----END PRIVATE KEY-----"
 # ALGORITHM=ed25519

--- a/packages/signer/README.md
+++ b/packages/signer/README.md
@@ -5,10 +5,10 @@ Produces cryptographically signed proofs of aggregated stock prices.
 ## Overview
 
 This package provides:
-- Cryptographic signing of price data
-- Proof generation for price attestations
-- Signature verification utilities
-- Key management integration
+- Ed25519 signing for aggregated price payloads
+- Stable proof serialization for downstream publishers/transactors
+- Boolean and throwing verification utilities
+- PEM-based key management support
 
 ## Getting Started
 
@@ -68,7 +68,96 @@ npm run lint
 After building, import the package in your application:
 
 ```typescript
-import { PriceData, SignedPriceProof } from '@oracle-stocks/signer';
+import {
+  PriceData,
+  assertValidSignedPriceProof,
+  signPriceData,
+  verifySignedPriceProof,
+} from '@oracle-stocks/signer';
+```
+
+### Key Formats
+
+`PRIVATE_KEY` should be an Ed25519 private key in PKCS#8 PEM format. Public keys should be Ed25519 SPKI PEM strings.
+
+Example private key:
+
+```pem
+-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIJExampleReplaceWithRealKeyMaterialgQy7q5sVfM+9Lx
+-----END PRIVATE KEY-----
+```
+
+Example public key:
+
+```pem
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAExampleReplaceWithRealKeyMaterial5L8sQ0Rk0PvN8hQ=
+-----END PUBLIC KEY-----
+```
+
+You can also pass Node.js `KeyObject` instances directly if your application already loads keys via `crypto`.
+
+### Signing
+
+```typescript
+const priceData: PriceData = {
+  symbol: 'AAPL',
+  price: 189.42,
+  timestamp: Date.now(),
+  source: 'aggregator',
+};
+
+const proof = signPriceData(priceData, {
+  privateKey: process.env.PRIVATE_KEY as string,
+  algorithm: 'ed25519',
+});
+
+console.log(proof);
+```
+
+Returned proofs follow the `SignedPriceProof` interface exactly:
+
+```json
+{
+  "data": {
+    "symbol": "AAPL",
+    "price": 189.42,
+    "timestamp": 1711459200000,
+    "source": "aggregator"
+  },
+  "signature": "<base64 signature>",
+  "publicKey": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n",
+  "timestamp": 1711459200123
+}
+```
+
+The signature is generated over a stable JSON payload containing:
+- `data`
+- `publicKey`
+- `timestamp`
+
+### Verification
+
+Use `verifySignedPriceProof` when you want a boolean result:
+
+```typescript
+const isValid = verifySignedPriceProof(proof);
+```
+
+Use `assertValidSignedPriceProof` when you want explicit errors:
+
+```typescript
+assertValidSignedPriceProof(proof);
+```
+
+You can also verify against externally supplied public key material instead of the embedded proof key:
+
+```typescript
+const isValid = verifySignedPriceProof(proof, {
+  publicKey: process.env.SIGNER_PUBLIC_KEY as string,
+  algorithm: 'ed25519',
+});
 ```
 
 ## Project Structure
@@ -77,13 +166,11 @@ import { PriceData, SignedPriceProof } from '@oracle-stocks/signer';
 packages/signer/
 ├── src/
 │   ├── index.ts       # Main entry point
+│   ├── signer.ts      # Signing and verification implementation
+│   ├── signer.spec.ts # Unit tests
 │   └── types.ts       # Type definitions
 ├── dist/              # Compiled output (generated)
 ├── package.json       # Dependencies and scripts
 ├── tsconfig.json      # TypeScript configuration
 └── README.md         # This file
 ```
-
-## Status
-
-🚧 Under construction - Signing logic will be implemented in subsequent issues.

--- a/packages/signer/src/index.ts
+++ b/packages/signer/src/index.ts
@@ -1,6 +1,4 @@
 // Main entry point for the Signer package
 
 export * from './types';
-
-// Signer functionality will be exported here
-// Example: export { signPriceData } from './signer';
+export * from './signer';

--- a/packages/signer/src/signer.spec.ts
+++ b/packages/signer/src/signer.spec.ts
@@ -1,0 +1,157 @@
+import { createPublicKey, generateKeyPairSync, verify as cryptoVerify } from 'crypto';
+import {
+  assertValidSignedPriceProof,
+  serializeProofPayload,
+  signPriceData,
+  SignedPriceProofVerificationError,
+  verifySignedPriceProof,
+} from './signer';
+import { PriceData, SignedPriceProof } from './types';
+
+describe('signer', () => {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  const privateKeyPem = privateKey.export({ format: 'pem', type: 'pkcs8' }) as string;
+  const publicKeyPem = publicKey.export({ format: 'pem', type: 'spki' }) as string;
+
+  const samplePriceData: PriceData = {
+    symbol: 'AAPL',
+    price: 189.42,
+    timestamp: 1711459200000,
+    source: 'aggregator',
+  };
+
+  it('signs and verifies a price proof using ed25519', () => {
+    const proof = signPriceData(samplePriceData, {
+      privateKey: privateKeyPem,
+      algorithm: 'ed25519',
+    });
+
+    expect(proof.data).toEqual(samplePriceData);
+    expect(proof.publicKey).toBe(publicKeyPem);
+    expect(typeof proof.signature).toBe('string');
+    expect(proof.signature.length).toBeGreaterThan(0);
+    expect(Number.isInteger(proof.timestamp)).toBe(true);
+    expect(verifySignedPriceProof(proof)).toBe(true);
+    expect(() => assertValidSignedPriceProof(proof)).not.toThrow();
+  });
+
+  it('serializes the signed payload with a stable JSON structure', () => {
+    const proof: SignedPriceProof = {
+      data: samplePriceData,
+      publicKey: publicKeyPem,
+      signature: 'unused',
+      timestamp: 1711459200123,
+    };
+
+    expect(serializeProofPayload(proof)).toBe(
+      JSON.stringify({
+        data: {
+          symbol: 'AAPL',
+          price: 189.42,
+          timestamp: 1711459200000,
+          source: 'aggregator',
+        },
+        publicKey: publicKeyPem,
+        timestamp: 1711459200123,
+      }),
+    );
+  });
+
+  it('fails verification when the signed payload is tampered with', () => {
+    const proof = signPriceData(samplePriceData, { privateKey: privateKeyPem });
+    const tamperedProof: SignedPriceProof = {
+      ...proof,
+      data: {
+        ...proof.data,
+        price: proof.data.price + 1,
+      },
+    };
+
+    expect(verifySignedPriceProof(tamperedProof)).toBe(false);
+    expect(() => assertValidSignedPriceProof(tamperedProof)).toThrow(
+      /signature verification failed/i,
+    );
+  });
+
+  it('fails verification when the signature is invalid', () => {
+    const proof = signPriceData(samplePriceData, { privateKey: privateKeyPem });
+    const invalidSignatureProof: SignedPriceProof = {
+      ...proof,
+      signature: Buffer.from('definitely-not-a-valid-signature').toString('base64'),
+    };
+
+    expect(verifySignedPriceProof(invalidSignatureProof)).toBe(false);
+    expect(() => assertValidSignedPriceProof(invalidSignatureProof)).toThrow(
+      /signature verification failed/i,
+    );
+  });
+
+  it('fails verification when a different public key is supplied', () => {
+    const proof = signPriceData(samplePriceData, { privateKey: privateKeyPem });
+    const otherKeys = generateKeyPairSync('ed25519');
+    const otherPublicKeyPem = otherKeys.publicKey.export({
+      format: 'pem',
+      type: 'spki',
+    }) as string;
+
+    expect(
+      verifySignedPriceProof(proof, {
+        publicKey: otherPublicKeyPem,
+      }),
+    ).toBe(false);
+  });
+
+  it('throws a clear error for malformed public key material', () => {
+    const proof = signPriceData(samplePriceData, { privateKey: privateKeyPem });
+
+    expect(() =>
+      assertValidSignedPriceProof(proof, {
+        publicKey: 'not-a-pem-key',
+      }),
+    ).toThrow(/invalid public key material/i);
+  });
+
+  it('supports signing with a KeyObject private key', () => {
+    const proof = signPriceData(samplePriceData, {
+      privateKey,
+    });
+
+    expect(verifySignedPriceProof(proof, { publicKey })).toBe(true);
+  });
+
+  it('matches Node crypto verification for the canonical payload', () => {
+    const proof = signPriceData(samplePriceData, {
+      privateKey: privateKeyPem,
+    });
+
+    const isValid = cryptoVerify(
+      null,
+      Buffer.from(serializeProofPayload(proof)),
+      publicKey,
+      Buffer.from(proof.signature, 'base64'),
+    );
+
+    expect(
+      verifySignedPriceProof(proof, {
+        publicKey: createPublicKey(publicKeyPem),
+      }),
+    ).toBe(true);
+    expect(isValid).toBe(true);
+  });
+
+  it('returns false while the assert helper throws on unsupported algorithms', () => {
+    const proof = signPriceData(samplePriceData, { privateKey: privateKeyPem });
+
+    expect(
+      verifySignedPriceProof(proof, {
+        algorithm: 'ed25519',
+      }),
+    ).toBe(true);
+
+    expect(() =>
+      assertValidSignedPriceProof(proof, {
+        algorithm: 'rsa' as never,
+      }),
+    ).toThrow(SignedPriceProofVerificationError);
+  });
+});

--- a/packages/signer/src/signer.ts
+++ b/packages/signer/src/signer.ts
@@ -1,0 +1,234 @@
+import {
+  createPrivateKey,
+  createPublicKey,
+  KeyObject,
+  sign,
+  verify,
+} from 'crypto';
+import {
+  KeyMaterial,
+  PriceData,
+  SignedPriceProof,
+  SignerAlgorithm,
+  SignerConfig,
+  VerifyProofOptions,
+} from './types';
+
+const DEFAULT_ALGORITHM: SignerAlgorithm = 'ed25519';
+
+export class SignedPriceProofVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SignedPriceProofVerificationError';
+  }
+}
+
+export function signPriceData(
+  data: PriceData,
+  config: SignerConfig,
+): SignedPriceProof {
+  assertSupportedAlgorithm(config.algorithm);
+  assertValidPriceData(data);
+
+  const privateKey = normalizePrivateKey(config.privateKey);
+  assertEd25519KeyType(privateKey, 'private');
+
+  const publicKeyPem = createPublicKey(privateKey).export({
+    format: 'pem',
+    type: 'spki',
+  }) as string;
+
+  const proof: SignedPriceProof = {
+    data: normalizePriceData(data),
+    signature: '',
+    publicKey: publicKeyPem,
+    timestamp: Date.now(),
+  };
+
+  proof.signature = sign(null, Buffer.from(serializeProofPayload(proof)), privateKey).toString(
+    'base64',
+  );
+
+  return proof;
+}
+
+export function verifySignedPriceProof(
+  proof: SignedPriceProof,
+  options: VerifyProofOptions = {},
+): boolean {
+  try {
+    assertValidSignedPriceProof(proof, options);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function assertValidSignedPriceProof(
+  proof: SignedPriceProof,
+  options: VerifyProofOptions = {},
+): void {
+  assertSupportedAlgorithm(options.algorithm);
+  assertPayloadShape(proof);
+
+  if (!proof.signature || typeof proof.signature !== 'string') {
+    throw new SignedPriceProofVerificationError(
+      'Signed price proof signature must be a base64-encoded string.',
+    );
+  }
+
+  const publicKeyMaterial = options.publicKey ?? proof.publicKey;
+  if (!publicKeyMaterial) {
+    throw new SignedPriceProofVerificationError(
+      'A public key is required to verify a signed price proof.',
+    );
+  }
+
+  const publicKey = normalizePublicKey(publicKeyMaterial);
+  assertEd25519KeyType(publicKey, 'public');
+
+  const signature = decodeBase64Signature(proof.signature);
+  const isValid = verify(
+    null,
+    Buffer.from(serializeProofPayload(proof)),
+    publicKey,
+    signature,
+  );
+
+  if (!isValid) {
+    throw new SignedPriceProofVerificationError(
+      'Signed price proof signature verification failed.',
+    );
+  }
+}
+
+export function serializeProofPayload(proof: SignedPriceProof): string {
+  assertPayloadShape(proof);
+
+  return JSON.stringify({
+    data: normalizePriceData(proof.data),
+    publicKey: proof.publicKey,
+    timestamp: proof.timestamp,
+  });
+}
+
+function normalizePrivateKey(privateKey: KeyMaterial): KeyObject {
+  try {
+    return privateKey instanceof KeyObject
+      ? privateKey
+      : createPrivateKey(privateKey);
+  } catch (error) {
+    throw new SignedPriceProofVerificationError(
+      `Invalid PRIVATE_KEY value. Expected an ed25519 private key in PKCS#8 PEM or KeyObject format: ${formatErrorMessage(
+        error,
+      )}`,
+    );
+  }
+}
+
+function normalizePublicKey(publicKey: KeyMaterial): KeyObject {
+  try {
+    return publicKey instanceof KeyObject ? publicKey : createPublicKey(publicKey);
+  } catch (error) {
+    throw new SignedPriceProofVerificationError(
+      `Invalid public key material. Expected an ed25519 public key in SPKI PEM or KeyObject format: ${formatErrorMessage(
+        error,
+      )}`,
+    );
+  }
+}
+
+function assertSupportedAlgorithm(algorithm?: string): void {
+  if (algorithm && algorithm !== DEFAULT_ALGORITHM) {
+    throw new SignedPriceProofVerificationError(
+      `Unsupported signing algorithm "${algorithm}". Expected "${DEFAULT_ALGORITHM}".`,
+    );
+  }
+}
+
+function assertValidPriceData(data: PriceData): void {
+  if (!data || typeof data !== 'object') {
+    throw new SignedPriceProofVerificationError('Price data must be an object.');
+  }
+
+  if (!data.symbol || typeof data.symbol !== 'string') {
+    throw new SignedPriceProofVerificationError('Price data symbol must be a non-empty string.');
+  }
+
+  if (!Number.isFinite(data.price)) {
+    throw new SignedPriceProofVerificationError('Price data price must be a finite number.');
+  }
+
+  if (!Number.isInteger(data.timestamp)) {
+    throw new SignedPriceProofVerificationError(
+      'Price data timestamp must be an integer Unix timestamp in milliseconds.',
+    );
+  }
+
+  if (data.source !== undefined && typeof data.source !== 'string') {
+    throw new SignedPriceProofVerificationError(
+      'Price data source must be a string when provided.',
+    );
+  }
+}
+
+function assertPayloadShape(proof: SignedPriceProof): void {
+  if (!proof || typeof proof !== 'object') {
+    throw new SignedPriceProofVerificationError('Signed price proof must be an object.');
+  }
+
+  assertValidPriceData(proof.data);
+
+  if (!proof.publicKey || typeof proof.publicKey !== 'string') {
+    throw new SignedPriceProofVerificationError(
+      'Signed price proof publicKey must be a PEM-encoded string.',
+    );
+  }
+
+  if (!Number.isInteger(proof.timestamp)) {
+    throw new SignedPriceProofVerificationError(
+      'Signed price proof timestamp must be an integer Unix timestamp in milliseconds.',
+    );
+  }
+}
+
+function normalizePriceData(data: PriceData): PriceData {
+  const normalized: PriceData = {
+    symbol: data.symbol,
+    price: data.price,
+    timestamp: data.timestamp,
+  };
+
+  if (data.source !== undefined) {
+    normalized.source = data.source;
+  }
+
+  return normalized;
+}
+
+function decodeBase64Signature(signature: string): Buffer {
+  try {
+    const decoded = Buffer.from(signature, 'base64');
+    if (decoded.length === 0) {
+      throw new Error('empty signature');
+    }
+
+    return decoded;
+  } catch (error) {
+    throw new SignedPriceProofVerificationError(
+      `Signed price proof signature is not valid base64: ${formatErrorMessage(error)}`,
+    );
+  }
+}
+
+function assertEd25519KeyType(key: KeyObject, kind: 'private' | 'public'): void {
+  if (key.asymmetricKeyType !== 'ed25519') {
+    throw new SignedPriceProofVerificationError(
+      `Expected an ed25519 ${kind} key but received "${key.asymmetricKeyType ?? 'unknown'}".`,
+    );
+  }
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/signer/src/types.ts
+++ b/packages/signer/src/types.ts
@@ -1,6 +1,11 @@
+import { KeyObject } from 'crypto';
+
 /**
  * Type definitions for the Signer package
  */
+
+export type SignerAlgorithm = 'ed25519';
+export type KeyMaterial = string | KeyObject;
 
 /**
  * Represents aggregated stock price data that will be signed
@@ -26,6 +31,14 @@ export interface SignedPriceProof {
  * Configuration options for signing
  */
 export interface SignerConfig {
-  privateKey: string;
-  algorithm?: string;
+  privateKey: KeyMaterial;
+  algorithm?: SignerAlgorithm;
+}
+
+/**
+ * Configuration options for verification
+ */
+export interface VerifyProofOptions {
+  publicKey?: KeyMaterial;
+  algorithm?: SignerAlgorithm;
 }

--- a/packages/signer/tsconfig.json
+++ b/packages/signer/tsconfig.json
@@ -13,7 +13,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.spec.ts"]


### PR DESCRIPTION
PR title:

feat(signer): implement ed25519 signing and verification for price proofs

PR description:

Summary
Implements the missing @oracle-stocks/signer ed25519 proof flow so downstream services can sign and verify authenticated SignedPriceProof payloads.

What was done
Added ed25519 signing logic for PriceData -> SignedPriceProof
Added proof verification helpers:
verifySignedPriceProof returns boolean
assertValidSignedPriceProof throws clear verification errors
Added stable proof serialization via serializeProofPayload
Derived and embedded the signer public key in the proof
Validated supported algorithm is ed25519
Documented expected key formats:
private key: PKCS#8 PEM
public key: SPKI PEM
KeyObject also supported
Exported new signer APIs from packages/signer/src/index.ts
Updated signer package README with signing and verification examples
Updated .env.example to reflect PEM private key usage
Added unit tests covering:
sign/verify happy path
tampered payload failure
invalid signature failure
wrong public key failure
malformed key input failure
stable JSON payload serialization
Node crypto verification parity
Validation
npm run check-types
npm test -- --runInBand

closes #40 